### PR TITLE
Add life expectancy decomposition toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,57 @@
 # US Health Disparities
 
-This repository contains cleaned code that the US Health Disparities team used to generate results for their publications.
+This repository contains cleaned code that the US Health Disparities team used to generate results for their publications. The
+`work` branch also provides lightweight utilities for constructing abridged life tables and decomposing life expectancy
+differences across counties for shared race, sex, and age cohorts.
+
+## Life expectancy decomposition utilities
+
+The reusable code lives under `src/ushd` and can be imported as a regular Python package. The two main entry points are
+`ushd.build_life_table`, which converts an age-specific mortality schedule into a life table, and
+`ushd.decompose_between_counties`, which applies a Horiuchi stepwise replacement decomposition to compute age-specific
+contributions to the life expectancy differential between two counties.
+
+```python
+from ushd import LifeTableInput, build_life_table, decompose_between_counties
+
+# Create a life table for a given mortality schedule.
+life_table = build_life_table(
+    LifeTableInput(
+        age_lower=[0, 1, 5],
+        age_upper=[1, 5, None],
+        mx=[0.005, 0.0008, 0.02],
+    )
+)
+
+# Decompose the life expectancy gap between two counties for a cohort.
+records = [
+    {"county": "A", "race": "Black", "sex": "Female", "age_lower": 0, "age_upper": 1, "mx": 0.005},
+    {"county": "A", "race": "Black", "sex": "Female", "age_lower": 1, "age_upper": 5, "mx": 0.0008},
+    {"county": "A", "race": "Black", "sex": "Female", "age_lower": 5, "age_upper": None, "mx": 0.02},
+    {"county": "B", "race": "Black", "sex": "Female", "age_lower": 0, "age_upper": 1, "mx": 0.006},
+    {"county": "B", "race": "Black", "sex": "Female", "age_lower": 1, "age_upper": 5, "mx": 0.001},
+    {"county": "B", "race": "Black", "sex": "Female", "age_lower": 5, "age_upper": None, "mx": 0.018},
+]
+
+contributions = decompose_between_counties(
+    records,
+    county_col="county",
+    race_col="race",
+    sex_col="sex",
+    age_lower_col="age_lower",
+    age_upper_col="age_upper",
+    mx_col="mx",
+    county_a="A",
+    county_b="B",
+    race="Black",
+    sex="Female",
+)
+
+for row in contributions:
+    print(row["age_lower"], row["age_upper"], row["contribution"])
+```
+
+Running the code above produces age-specific contributions whose sum equals the life expectancy gap between the counties.
 
 ## Navigating this repository
 

--- a/src/ushd/__init__.py
+++ b/src/ushd/__init__.py
@@ -1,0 +1,17 @@
+"""Utilities for working with US Health Disparities life tables."""
+
+from .life_table import LifeTable, LifeTableInput, build_life_table
+from .decomposition import (
+    DecompositionResult,
+    decompose_between_counties,
+    horiuchi_decomposition,
+)
+
+__all__ = [
+    "LifeTable",
+    "LifeTableInput",
+    "build_life_table",
+    "DecompositionResult",
+    "horiuchi_decomposition",
+    "decompose_between_counties",
+]

--- a/src/ushd/decomposition.py
+++ b/src/ushd/decomposition.py
@@ -1,0 +1,192 @@
+"""Life expectancy decomposition using stepwise replacement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from .life_table import LifeTableInput, build_life_table
+
+
+@dataclass
+class DecompositionResult:
+    age_lower: List[float]
+    age_upper: List[Optional[float]]
+    contribution: List[float]
+
+    def to_records(self) -> List[dict]:
+        return [
+            {
+                "age_lower": self.age_lower[i],
+                "age_upper": self.age_upper[i],
+                "contribution": self.contribution[i],
+            }
+            for i in range(len(self.age_lower))
+        ]
+
+    def to_pandas(self):  # pragma: no cover - optional dependency
+        try:
+            import pandas as pd
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError("pandas is required to create a DataFrame") from exc
+        return pd.DataFrame(self.to_records())
+
+
+def _life_expectancy_from_mx(
+    mx: Sequence[float],
+    age_lower: Sequence[float],
+    age_upper: Sequence[Optional[float]],
+    ax: Optional[Sequence[float]],
+) -> float:
+    table = build_life_table(
+        LifeTableInput(age_lower=age_lower, age_upper=age_upper, mx=mx, ax=ax)
+    )
+    return table.ex[0]
+
+
+def _numeric_gradient(
+    func,
+    mx: Sequence[float],
+    step: float = 1e-5,
+) -> List[float]:
+    gradients: List[float] = []
+    for idx in range(len(mx)):
+        perturbed = list(mx)
+        perturbed[idx] += step
+        upper = func(perturbed)
+        perturbed[idx] -= 2 * step
+        lower = func(perturbed)
+        gradients.append((upper - lower) / (2 * step))
+    return gradients
+
+
+def horiuchi_decomposition(
+    baseline_mx: Iterable[float],
+    comparison_mx: Iterable[float],
+    age_lower: Iterable[float],
+    age_upper: Iterable[Optional[float]],
+    ax: Optional[Iterable[float]] = None,
+    steps: int = 50,
+) -> DecompositionResult:
+    baseline = list(map(float, baseline_mx))
+    comparison = list(map(float, comparison_mx))
+    if len(baseline) != len(comparison):
+        raise ValueError("baseline_mx and comparison_mx must have the same length")
+
+    age_lower = list(map(float, age_lower))
+    age_upper = [None if val is None else float(val) for val in age_upper]
+    ax = None if ax is None else list(map(float, ax))
+
+    def func(values: Sequence[float]) -> float:
+        return _life_expectancy_from_mx(values, age_lower, age_upper, ax)
+
+    delta = [b - a for a, b in zip(baseline, comparison)]
+    contributions = [0.0 for _ in delta]
+    for step_idx in range(steps):
+        weight = (step_idx + 0.5) / steps
+        mx_step = [a + weight * d for a, d in zip(baseline, delta)]
+        gradient = _numeric_gradient(func, mx_step)
+        for i, (grad, diff) in enumerate(zip(gradient, delta)):
+            contributions[i] += grad * diff / steps
+
+    return DecompositionResult(
+        age_lower=age_lower,
+        age_upper=age_upper,
+        contribution=contributions,
+    )
+
+
+def _ensure_records(data) -> List[Mapping[str, object]]:
+    if isinstance(data, list):
+        return data  # assume list of dict-like structures
+    if hasattr(data, "to_dict"):
+        try:
+            return data.to_dict("records")  # type: ignore[call-arg]
+        except TypeError:
+            pass
+    raise TypeError("data must be a list of mappings or a pandas DataFrame")
+
+
+def _key(age_lower: object, age_upper: object) -> Tuple[float, Optional[float]]:
+    lower = float(age_lower)
+    upper = None if age_upper is None else float(age_upper)
+    return lower, upper
+
+
+def decompose_between_counties(
+    data,
+    county_col: str,
+    race_col: str,
+    sex_col: str,
+    age_lower_col: str,
+    age_upper_col: str,
+    mx_col: str,
+    county_a: str,
+    county_b: str,
+    race: str,
+    sex: str,
+    ax_col: Optional[str] = None,
+    steps: int = 50,
+) -> List[dict]:
+    records = _ensure_records(data)
+    cohort = [row for row in records if row.get(race_col) == race and row.get(sex_col) == sex]
+    if not cohort:
+        raise ValueError("No rows found for the specified race/sex cohort")
+
+    county_a_rows = [row for row in cohort if row.get(county_col) == county_a]
+    county_b_rows = [row for row in cohort if row.get(county_col) == county_b]
+    if not county_a_rows or not county_b_rows:
+        raise ValueError("Both counties must have data for the specified cohort")
+
+    index_a = {
+        _key(row[age_lower_col], row[age_upper_col]): row for row in county_a_rows
+    }
+    index_b = {
+        _key(row[age_lower_col], row[age_upper_col]): row for row in county_b_rows
+    }
+
+    common_keys = sorted(set(index_a.keys()) & set(index_b.keys()))
+    if not common_keys:
+        raise ValueError("No overlapping age groups available for decomposition")
+
+    baseline_mx = [float(index_a[key][mx_col]) for key in common_keys]
+    comparison_mx = [float(index_b[key][mx_col]) for key in common_keys]
+    age_lower = [key[0] for key in common_keys]
+    age_upper = [key[1] for key in common_keys]
+
+    ax_values: Optional[List[float]] = None
+    if ax_col is not None:
+        collected: List[float] = []
+        for key in common_keys:
+            val_a = index_a[key].get(ax_col)
+            val_b = index_b[key].get(ax_col)
+            chosen = val_a if val_a is not None else val_b
+            if chosen is None:
+                collected = []
+                break
+            collected.append(float(chosen))
+        if collected:
+            ax_values = collected
+
+    result = horiuchi_decomposition(
+        baseline_mx=baseline_mx,
+        comparison_mx=comparison_mx,
+        age_lower=age_lower,
+        age_upper=age_upper,
+        ax=ax_values,
+        steps=steps,
+    )
+
+    total_gap = sum(result.contribution)
+    output = result.to_records()
+    for row in output:
+        row.update(
+            {
+                "county_a": county_a,
+                "county_b": county_b,
+                "race": race,
+                "sex": sex,
+                "life_expectancy_difference": total_gap,
+            }
+        )
+    return output

--- a/src/ushd/life_table.py
+++ b/src/ushd/life_table.py
@@ -1,0 +1,182 @@
+"""Lightweight life table utilities used by the decomposition toolkit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence
+
+
+@dataclass
+class LifeTable:
+    """Representation of an abridged life table."""
+
+    age_lower: List[float]
+    age_upper: List[Optional[float]]
+    n: List[Optional[float]]
+    mx: List[float]
+    ax: List[float]
+    qx: List[float]
+    px: List[float]
+    lx: List[float]
+    dx: List[float]
+    Lx: List[float]
+    Tx: List[float]
+    ex: List[float]
+
+    def column(self, name: str) -> List[float]:
+        return getattr(self, name)
+
+    def to_dicts(self) -> List[dict]:
+        return [
+            {
+                "age_lower": self.age_lower[i],
+                "age_upper": self.age_upper[i],
+                "n": self.n[i],
+                "mx": self.mx[i],
+                "ax": self.ax[i],
+                "qx": self.qx[i],
+                "px": self.px[i],
+                "lx": self.lx[i],
+                "dx": self.dx[i],
+                "Lx": self.Lx[i],
+                "Tx": self.Tx[i],
+                "ex": self.ex[i],
+            }
+            for i in range(len(self.mx))
+        ]
+
+    def to_pandas(self):  # pragma: no cover - optional dependency
+        try:
+            import pandas as pd
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError("pandas is required to convert to a DataFrame") from exc
+        return pd.DataFrame(self.to_dicts())
+
+
+@dataclass
+class LifeTableInput:
+    age_lower: Iterable[float]
+    age_upper: Iterable[Optional[float]]
+    mx: Iterable[float]
+    ax: Optional[Iterable[float]] = None
+    radix: float = 100_000.0
+
+
+def _validate_inputs(data: LifeTableInput) -> None:
+    age_lower = list(data.age_lower)
+    age_upper = list(data.age_upper)
+    mx = list(data.mx)
+
+    if not (len(age_lower) == len(age_upper) == len(mx)):
+        raise ValueError("age_lower, age_upper, and mx must have the same length")
+    if len(age_lower) < 2:
+        raise ValueError("Life tables require at least two age groups")
+
+    for i, (low, high) in enumerate(zip(age_lower, age_upper)):
+        if high is not None and high <= low:
+            raise ValueError(f"age_upper must exceed age_lower at row {i}")
+
+    if data.ax is not None:
+        ax_list = list(data.ax)
+        if len(ax_list) != len(age_lower):
+            raise ValueError("ax must have the same length as the age vectors")
+
+    if any(high is None for high in age_upper[:-1]):
+        raise ValueError("Only the final age group may be open-ended")
+
+
+def _compute_ax(
+    age_lower: Sequence[float],
+    age_upper: Sequence[Optional[float]],
+    mx: Sequence[float],
+) -> List[float]:
+    ax: List[float] = []
+    for low, high, rate in zip(age_lower, age_upper, mx):
+        if high is None:
+            ax.append(1.0 / max(rate, 1e-12))
+        else:
+            ax.append((high - low) / 2.0)
+    return ax
+
+
+def build_life_table(data: LifeTableInput) -> LifeTable:
+    age_lower_list = list(data.age_lower)
+    age_upper_list = list(data.age_upper)
+    mx_list = list(data.mx)
+    ax_list = list(data.ax) if data.ax is not None else None
+
+    _validate_inputs(
+        LifeTableInput(
+            age_lower=age_lower_list,
+            age_upper=age_upper_list,
+            mx=mx_list,
+            ax=ax_list,
+            radix=data.radix,
+        )
+    )
+
+    age_lower = list(map(float, age_lower_list))
+    age_upper = [None if val is None else float(val) for val in age_upper_list]
+    mx = [float(val) for val in mx_list]
+    if any(rate < 0 for rate in mx):
+        raise ValueError("Mortality rates must be non-negative")
+
+    ax = (
+        [float(val) for val in ax_list]
+        if ax_list is not None
+        else _compute_ax(age_lower, age_upper, mx)
+    )
+
+    n: List[Optional[float]] = []
+    for low, high in zip(age_lower, age_upper):
+        if high is None:
+            n.append(None)
+        else:
+            n.append(high - low)
+
+    qx: List[float] = []
+    for width, rate, a in zip(n, mx, ax):
+        if width is None:
+            qx.append(1.0)
+        else:
+            numerator = width * rate
+            denominator = 1.0 + (width - a) * rate
+            value = numerator / denominator if denominator else 1.0
+            qx.append(max(0.0, min(1.0, value)))
+
+    px = [1.0 - value for value in qx]
+
+    lx: List[float] = [data.radix]
+    for prob in px[:-1]:
+        lx.append(lx[-1] * prob)
+
+    dx = [l * q for l, q in zip(lx, qx)]
+
+    Lx: List[float] = []
+    for width, l_val, d_val, a, rate in zip(n, lx, dx, ax, mx):
+        if width is None:
+            Lx.append(l_val / max(rate, 1e-12))
+        else:
+            Lx.append(width * (l_val - d_val) + a * d_val)
+
+    Tx: List[float] = [0.0] * len(Lx)
+    Tx[-1] = Lx[-1]
+    for i in range(len(Lx) - 2, -1, -1):
+        Tx[i] = Tx[i + 1] + Lx[i]
+
+    ex = [t / l if l else 0.0 for t, l in zip(Tx, lx)]
+
+    return LifeTable(
+        age_lower=age_lower,
+        age_upper=age_upper,
+        n=n,
+        mx=mx,
+        ax=ax,
+        qx=qx,
+        px=px,
+        lx=lx,
+        dx=dx,
+        Lx=Lx,
+        Tx=Tx,
+        ex=ex,
+    )

--- a/tests/test_decomposition.py
+++ b/tests/test_decomposition.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+
+from ushd import LifeTableInput, build_life_table, decompose_between_counties, horiuchi_decomposition
+
+
+class DecompositionTests(unittest.TestCase):
+    def test_build_life_table_monotonic_lx(self):
+        table = build_life_table(
+            LifeTableInput(
+                age_lower=[0, 1, 5],
+                age_upper=[1, 5, None],
+                mx=[0.005, 0.0008, 0.02],
+            )
+        )
+        lx = table.lx
+        self.assertTrue(all(lx[i + 1] <= lx[i] for i in range(len(lx) - 1)))
+        self.assertGreater(table.ex[0], table.ex[1])
+
+    def test_horiuchi_decomposition_matches_direct_difference(self):
+        age_lower = [0, 1, 5]
+        age_upper = [1, 5, None]
+        county_a_mx = [0.005, 0.0008, 0.02]
+        county_b_mx = [0.006, 0.001, 0.018]
+
+        result = horiuchi_decomposition(
+            baseline_mx=county_a_mx,
+            comparison_mx=county_b_mx,
+            age_lower=age_lower,
+            age_upper=age_upper,
+        )
+
+        table_a = build_life_table(
+            LifeTableInput(age_lower=age_lower, age_upper=age_upper, mx=county_a_mx)
+        )
+        table_b = build_life_table(
+            LifeTableInput(age_lower=age_lower, age_upper=age_upper, mx=county_b_mx)
+        )
+        diff = table_b.ex[0] - table_a.ex[0]
+        total = sum(result.contribution)
+        self.assertLess(abs(total - diff), 1e-3)
+
+    def test_decompose_between_counties_round_trip(self):
+        records = [
+            {"county": "A", "race": "White", "sex": "Female", "age_lower": 0, "age_upper": 1, "mx": 0.005},
+            {"county": "A", "race": "White", "sex": "Female", "age_lower": 1, "age_upper": 5, "mx": 0.0008},
+            {"county": "A", "race": "White", "sex": "Female", "age_lower": 5, "age_upper": None, "mx": 0.02},
+            {"county": "B", "race": "White", "sex": "Female", "age_lower": 0, "age_upper": 1, "mx": 0.006},
+            {"county": "B", "race": "White", "sex": "Female", "age_lower": 1, "age_upper": 5, "mx": 0.001},
+            {"county": "B", "race": "White", "sex": "Female", "age_lower": 5, "age_upper": None, "mx": 0.018},
+        ]
+
+        contributions = decompose_between_counties(
+            records,
+            county_col="county",
+            race_col="race",
+            sex_col="sex",
+            age_lower_col="age_lower",
+            age_upper_col="age_upper",
+            mx_col="mx",
+            county_a="A",
+            county_b="B",
+            race="White",
+            sex="Female",
+        )
+
+        total_gap = contributions[0]["life_expectancy_difference"]
+        self.assertLess(abs(sum(row["contribution"] for row in contributions) - total_gap), 1e-3)
+        for row in contributions:
+            self.assertEqual(row["county_a"], "A")
+            self.assertEqual(row["county_b"], "B")
+            self.assertEqual(row["race"], "White")
+            self.assertEqual(row["sex"], "Female")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a pure-Python life table builder and Horiuchi-based decomposition utilities under `src/ushd`
- expose the helpers through the package namespace and document their usage in the README
- cover the new functionality with unit tests that verify life table properties and decomposition behaviour

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68d31f5c9bbc83209f99871994e22f55